### PR TITLE
refactor: Added utility to escape backticks in JSON strings

### DIFF
--- a/src/query-performance-monitoring/constants/constants.go
+++ b/src/query-performance-monitoring/constants/constants.go
@@ -22,7 +22,7 @@ const (
 		SupportedStatements defines the SQL statements for which this integration fetches query execution plans.
 		Restricting the supported statements improves compatibility and reduces the complexity of plan analysis.
 	*/
-	SupportedStatements = "SELECT INSERT UPDATE DELETE WITH"
+	SupportedStatements = "SELECT WITH"
 
 	/*
 		QueryPlanTimeoutDuration sets the timeout for fetching query execution plans.

--- a/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
+++ b/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
@@ -106,10 +106,14 @@ func processExecutionPlanMetrics(db utils.DataSource, query utils.IndividualQuer
 	return dbPerformanceEvents, nil
 }
 
-// Escape backticks in the entire JSON string.
+// Escape backticks and other special characters in the entire JSON string.
 func escapeInJSONString(jsonString string) string {
 	// Replace backticks with escaped backticks
-	return strings.ReplaceAll(jsonString, "`", "\\`")
+	escapedJson := strings.ReplaceAll(jsonString, "`", "\\`")
+	// Escape other special characters if necessary
+	escapedJson = strings.ReplaceAll(escapedJson, "\\", "\\\\")
+	escapedJson = strings.ReplaceAll(escapedJson, "\"", "\\\"")
+	return escapedJson
 }
 
 // extractMetricsFromJSONString extracts metrics from a JSON string.

--- a/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
+++ b/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
@@ -103,9 +103,18 @@ func processExecutionPlanMetrics(db utils.DataSource, query utils.IndividualQuer
 	return dbPerformanceEvents, nil
 }
 
+// Escape backticks in the entire JSON string.
+func escapeInJSONString(jsonString string) string {
+	// Replace backticks with escaped backticks
+	return strings.ReplaceAll(jsonString, "`", "\\`")
+}
+
 // extractMetricsFromJSONString extracts metrics from a JSON string.
 func extractMetricsFromJSONString(jsonString string, eventID uint64, threadID uint64) ([]utils.QueryPlanMetrics, error) {
-	js, err := simplejson.NewJson([]byte(jsonString))
+	// Escape backticks in the JSON string
+	escapedJson := escapeInJSONString(jsonString)
+
+	js, err := simplejson.NewJson([]byte(escapedJson))
 	if err != nil {
 		log.Error("Error creating simplejson from byte slice: %v", err)
 		return []utils.QueryPlanMetrics{}, err

--- a/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
+++ b/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan.go
@@ -94,8 +94,11 @@ func processExecutionPlanMetrics(db utils.DataSource, query utils.IndividualQuer
 		return []utils.QueryPlanMetrics{}, nil
 	}
 
+	// Escape backticks in the JSON string
+	escapedJson := escapeInJSONString(execPlanJSON)
+
 	// Extract metrics from the JSON string
-	dbPerformanceEvents, err := extractMetricsFromJSONString(execPlanJSON, *query.EventID, *query.ThreadID)
+	dbPerformanceEvents, err := extractMetricsFromJSONString(escapedJson, *query.EventID, *query.ThreadID)
 	if err != nil {
 		return []utils.QueryPlanMetrics{}, err
 	}
@@ -111,10 +114,7 @@ func escapeInJSONString(jsonString string) string {
 
 // extractMetricsFromJSONString extracts metrics from a JSON string.
 func extractMetricsFromJSONString(jsonString string, eventID uint64, threadID uint64) ([]utils.QueryPlanMetrics, error) {
-	// Escape backticks in the JSON string
-	escapedJson := escapeInJSONString(jsonString)
-
-	js, err := simplejson.NewJson([]byte(escapedJson))
+	js, err := simplejson.NewJson([]byte(jsonString))
 	if err != nil {
 		log.Error("Error creating simplejson from byte slice: %v", err)
 		return []utils.QueryPlanMetrics{}, err

--- a/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan_test.go
+++ b/src/query-performance-monitoring/performance-metrics-collectors/query_execution_plan_test.go
@@ -119,15 +119,15 @@ func TestSetExecutionPlanMetrics(t *testing.T) {
 func TestIsSupportedStatement(t *testing.T) {
 	t.Run("Supported Statement", func(t *testing.T) {
 		assert.True(t, isSupportedStatement("SELECT * FROM test"))
-		assert.True(t, isSupportedStatement("INSERT INTO test VALUES (1)"))
-		assert.True(t, isSupportedStatement("UPDATE test SET value = 1"))
-		assert.True(t, isSupportedStatement("DELETE FROM test"))
 		assert.True(t, isSupportedStatement("WITH cte AS (SELECT * FROM test) SELECT * FROM cte"))
 	})
 
 	t.Run("Unsupported Statement", func(t *testing.T) {
 		assert.False(t, isSupportedStatement("DROP TABLE test"))
 		assert.False(t, isSupportedStatement("ALTER TABLE test ADD COLUMN value INT"))
+		assert.False(t, isSupportedStatement("INSERT INTO test VALUES (1)"))
+		assert.False(t, isSupportedStatement("UPDATE test SET value = 1"))
+		assert.False(t, isSupportedStatement("DELETE FROM test"))
 	})
 }
 


### PR DESCRIPTION
1. Remove unnecessary data modification privileges for EXPLAIN
2. Added utility to escape backticks in JSON strings
3. The monitoring user now only has SELECT, PROCESS, and REPLICATION CLIENT privileges, further improving security.